### PR TITLE
Add flash storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 var User = require('./models/user');
 var Choral = require('./models/choral');
+var flash = require('express-flash-2');
 
 // auth stuff
 const session = require('express-session')
@@ -33,6 +34,9 @@ app.use(session({
   resave: false,
   saveUninitialized: false
 }))
+
+// flash is stored in the session, so this declaration must come after session setup
+app.use(flash());
 
 app.use(passport.initialize())
 app.use(passport.session())

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "debug": "~2.6.3",
     "epoch-charting": "^0.8.4",
     "express": "~4.15.2",
+    "express-flash-2": "^1.0.1",
     "express-session": "^1.15.3",
     "mongoose": "^4.11.1",
     "mongoose-unique-validator": "^1.0.5",


### PR DESCRIPTION
Allows for setting flash messages nicely anywhere in the request lifecycle, e.g. success or error messages.