### PR TITLE
Children chorals are opened with the same timeFrame as the parent

### DIFF
--- a/views/choral.pug
+++ b/views/choral.pug
@@ -30,7 +30,7 @@ block content
       - if( !(Object.keys(childData).length === 0 && childData.constructor === Object) )
         h3.child-area-head Children
         each child in childData
-          div.child-card(onclick="location.href='/chorals/"+child.choralId+"';")
+          div.child-card(onclick="location.href='/chorals/"+child.choralId+"?timeFrame=" + timeFrame + "';")
             h4.child-card-header= child.name
             div.child-card-body
               - var device_data = JSON.parse(child.device_data);


### PR DESCRIPTION
When you click on a child card with the timeframe as 1 day the child should also open in the one day view